### PR TITLE
Add lyrics export from Artist class to .txt or .json formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # May not want to commit lyrics text files
 *.txt
+*.json
 
 # Jupyter
 /Notebooks

--- a/lyricsgenius/artist.py
+++ b/lyricsgenius/artist.py
@@ -59,9 +59,24 @@ class Artist(object):
         self.add_song(song)
         return
 
-    def save_lyrics(self, format='json', filename=None, overwrite=False):
+    def save_lyrics(self, format='json', filename=None, overwrite=False, skip_duplicates=True):
         """Allows user to save all lyrics within an Artist obejct to a .json or .txt file."""
         assert (format == 'json') or (format == 'txt'), "Format must be json or txt"
+
+        # We want to reject songs that have already been added to artist collection
+        def songsAreSame(s1, s2):
+            from difflib import SequenceMatcher as sm # For comparing similarity of lyrics
+            # Idea credit: https://bigishdata.com/2016/10/25/talkin-bout-trucks-beer-and-love-in-country-songs-analyzing-genius-lyrics/
+            seqA = sm(None, s1.lyrics, s2['lyrics'])
+            seqB = sm(None, s2['lyrics'], s1.lyrics)
+            return seqA.ratio() > 0.5 or seqB.ratio() > 0.5
+
+        def songInArtist(new_song):    
+            # artist_lyrics is global (works in Jupyter notebook)
+            for song in lyrics_to_write['songs']:
+                if songsAreSame(new_song, song):
+                    return True
+            return False
 
         # Determine the filename
         if filename is None:
@@ -81,20 +96,33 @@ class Artist(object):
                 
         # Format lyrics in either .txt or .json format
         if format == 'json':
-            raise NotImplementedError
+            lyrics_to_write = {'songs': [], 'name': self.name}
+            for song in self.songs:
+                if skip_duplicates is False or not songInArtist(song): # This takes way too long! It's basically O(n^2), can I do better?
+                    lyrics_to_write['songs'].append({})
+                    lyrics_to_write['songs'][-1]['title']  = song.title
+                    lyrics_to_write['songs'][-1]['album']  = song.album
+                    lyrics_to_write['songs'][-1]['year']   = song.year
+                    lyrics_to_write['songs'][-1]['lyrics'] = song.lyrics                
+                    lyrics_to_write['songs'][-1]['image']  = song.song_art_image_url
+                    lyrics_to_write['songs'][-1]['artist'] = self.name
+                    lyrics_to_write['songs'][-1]['json']   = song._body
+                else:
+                    print("SKIPPING \"{}\" -- already found in artist collection.".format(song.title))
         else:
             lyrics_to_write = " ".join([s.lyrics + 5*'\n' for s in self.songs])
 
         # Write the lyrics to either a .json or .txt file
         if write_file:
-            try:
-                with open(filename, 'w') as lyrics_file:
+            with open(filename, 'w') as lyrics_file:
+                if format == 'json':                    
+                    json.dump(lyrics_to_write, lyrics_file)
+                else:    
                     lyrics_file.write(lyrics_to_write)
-                print('Wrote {} songs to {}.'.format(self.num_songs, filename))
-            except:
-                raise # TODO: Not sure if this how to do it
+            print('Wrote {} songs to {}.'.format(self.num_songs, filename))
         else:
-            print('Skipping file save.\n')
+            print('Skipping file save.\n')    
+        return lyrics_to_write
 
     def __str__(self):
         """Return a string representation of the Artist object."""                        

--- a/lyricsgenius/artist.py
+++ b/lyricsgenius/artist.py
@@ -1,3 +1,9 @@
+import json, os
+try:
+    input = raw_input # python 2
+except:
+    pass
+
 class Artist(object):
     """An artist from the Genius.com database.
     
@@ -52,6 +58,43 @@ class Artist(object):
         song = Genius.search_song(song_name,self.name)
         self.add_song(song)
         return
+
+    def save_lyrics(self, format='json', filename=None, overwrite=False):
+        """Allows user to save all lyrics within an Artist obejct to a .json or .txt file."""
+        assert (format == 'json') or (format == 'txt'), "Format must be json or txt"
+
+        # Determine the filename
+        if filename is None:
+            filename = "Lyrics_{}.{}".format(self.name.replace(" ",""), format)
+        else:
+            filename = filename.split('.')[0] + '.' + format
+            
+        # Check if file already exists    
+        write_file = False
+        if not os.path.isfile(filename):
+            write_file = True
+        elif overwrite:
+            write_file = True
+        else:
+            if input("{} already exists. Overwrite?\n(y/n): ".format(filename)).lower() == 'y':
+                write_file = True
+                
+        # Format lyrics in either .txt or .json format
+        if format == 'json':
+            raise NotImplementedError
+        else:
+            lyrics_to_write = " ".join([s.lyrics + 5*'\n' for s in self.songs])
+
+        # Write the lyrics to either a .json or .txt file
+        if write_file:
+            try:
+                with open(filename, 'w') as lyrics_file:
+                    lyrics_file.write(lyrics_to_write)
+                print('Wrote {} songs to {}.'.format(self.num_songs, filename))
+            except:
+                raise # TODO: Not sure if this how to do it
+        else:
+            print('Skipping file save.\n')
 
     def __str__(self):
         """Return a string representation of the Artist object."""                        

--- a/lyricsgenius/song.py
+++ b/lyricsgenius/song.py
@@ -36,7 +36,10 @@ class Song(object):
             
     @property
     def year(self):
-        return self._body['release_date']
+        try:
+            return self._body['release_date']
+        except:
+            return None
     
     @property
     def url(self):
@@ -66,7 +69,10 @@ class Song(object):
     
     @property
     def song_art_image_url(self):
-        return self._body['song_art_image_url']
+        try:
+            return self._body['song_art_image_url']
+        except:
+            return None
 
     def __str__(self):
         """Return a string representation of the Song object."""

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='lyricsgenius',
-    version='0.1.2',
+    version='0.2',
     description='Download lyrics and metadata from Genius.com',
     long_description=README,
     classifiers=[

--- a/tests/test_genius.py
+++ b/tests/test_genius.py
@@ -38,11 +38,10 @@ class TestArtist(unittest.TestCase):
 		self.assertEqual(self.artist.num_songs, self.max_songs, msg)
 
 	def test_saving_json_file(self):
-		raise NotImplementedError
 		print('\n')		
 		format = 'json'
 		msg = "Could not save {} file.".format(format)
-		expected_filename = 'lyrics_save_test_file.' + format
+		expected_filename = 'tests/lyrics_save_test_file.' + format
 		filename = expected_filename.split('.')[0]
 
 		# Remove the test file if it already exists
@@ -65,7 +64,7 @@ class TestArtist(unittest.TestCase):
 		print('\n')
 		format = 'txt'
 		msg = "Could not save {} file.".format(format)
-		expected_filename = 'lyrics_save_test_file.' + format
+		expected_filename = 'tests/lyrics_save_test_file.' + format
 		filename = expected_filename.split('.')[0]
 
 		# Remove the test file if it already exists

--- a/tests/test_genius.py
+++ b/tests/test_genius.py
@@ -37,6 +37,52 @@ class TestArtist(unittest.TestCase):
 		self.artist.add_song(api.search_song("These Days","Jackson Browne"))
 		self.assertEqual(self.artist.num_songs, self.max_songs, msg)
 
+	def test_saving_json_file(self):
+		raise NotImplementedError
+		print('\n')		
+		format = 'json'
+		msg = "Could not save {} file.".format(format)
+		expected_filename = 'lyrics_save_test_file.' + format
+		filename = expected_filename.split('.')[0]
+
+		# Remove the test file if it already exists
+		if os.path.isfile(expected_filename):
+			os.remove(expected_filename)
+
+		# Test saving json file
+		self.artist.save_lyrics(filename=filename, format=format)
+		self.assertTrue(os.path.isfile(expected_filename), msg)
+
+		# Test overwriting json file
+		try:
+			self.artist.save_lyrics(filename=filename, format=format, overwrite=True)
+			os.remove(expected_filename)
+		except:
+			self.fail("Failed {} overwrite test".format(format))
+			os.remove(expected_filename)
+
+	def test_saving_txt_file(self):
+		print('\n')
+		format = 'txt'
+		msg = "Could not save {} file.".format(format)
+		expected_filename = 'lyrics_save_test_file.' + format
+		filename = expected_filename.split('.')[0]
+
+		# Remove the test file if it already exists
+		if os.path.isfile(expected_filename):
+			os.remove(expected_filename)
+
+		# Test saving txt file
+		self.artist.save_lyrics(filename=filename, format=format)
+		self.assertTrue(os.path.isfile(expected_filename), msg)
+
+		# Test overwriting txt file
+		try:
+			self.artist.save_lyrics(filename=filename, format=format, overwrite=True)
+			os.remove(expected_filename)
+		except:
+			self.fail("Failed {} overwrite test".format(format))
+			os.remove(expected_filename)
 
 class TestSong(unittest.TestCase):
 


### PR DESCRIPTION
This PR closes #13 and #11. The `Artist` class now has a `save_lyrics()` method that gives the user the option to export all lyrics in an artist object into either `.json` or `.txt` format. The PR also includes unit tests for both export options. I guess to fully address #11 I should add a `save_lyrics` method to the `Song` class, but I'm not going to do that now. I will do that later.

Usage:
```python
artist = api.search_artist("Andy Shauf", max_songs=3)

# Method includes optional params: format, filename, overwrite, skip_duplicates
# Default format is .json
artist.save_lyrics()
```