### PR TITLE
Add Song.save_lyrics() method and tests

### DIFF
--- a/lyricsgenius/artist.py
+++ b/lyricsgenius/artist.py
@@ -61,6 +61,8 @@ class Artist(object):
 
     def save_lyrics(self, format='json', filename=None, overwrite=False, skip_duplicates=True):
         """Allows user to save all lyrics within an Artist obejct to a .json or .txt file."""
+        if format[0] == '.':
+            format = format[1:]        
         assert (format == 'json') or (format == 'txt'), "Format must be json or txt"
 
         # We want to reject songs that have already been added to artist collection
@@ -96,7 +98,7 @@ class Artist(object):
                 
         # Format lyrics in either .txt or .json format
         if format == 'json':
-            lyrics_to_write = {'songs': [], 'name': self.name}
+            lyrics_to_write = {'songs': [], 'artist': self.name}
             for song in self.songs:
                 if skip_duplicates is False or not songInArtist(song): # This takes way too long! It's basically O(n^2), can I do better?
                     lyrics_to_write['songs'].append({})

--- a/tests/test_genius.py
+++ b/tests/test_genius.py
@@ -122,3 +122,49 @@ class TestSong(unittest.TestCase):
 		msg = "The returned song does not have a media attribute."
 		self.assertTrue(hasattr(self.song, 'media'), msg)
 
+	def test_saving_json_file(self):
+		print('\n')		
+		format = 'json'
+		msg = "Could not save {} file.".format(format)
+		expected_filename = 'tests/lyrics_save_test_file.' + format
+		filename = expected_filename.split('.')[0]
+
+		# Remove the test file if it already exists
+		if os.path.isfile(expected_filename):
+			os.remove(expected_filename)
+
+		# Test saving json file
+		self.song.save_lyrics(filename=filename, format=format)
+		self.assertTrue(os.path.isfile(expected_filename), msg)
+
+		# Test overwriting json file
+		try:
+			self.song.save_lyrics(filename=filename, format=format, overwrite=True)
+			os.remove(expected_filename)
+		except:
+			self.fail("Failed {} overwrite test".format(format))
+			os.remove(expected_filename)
+
+	def test_saving_txt_file(self):
+		print('\n')
+		format = 'txt'
+		msg = "Could not save {} file.".format(format)
+		expected_filename = 'tests/lyrics_save_test_file.' + format
+		filename = expected_filename.split('.')[0]
+
+		# Remove the test file if it already exists
+		if os.path.isfile(expected_filename):
+			os.remove(expected_filename)
+
+		# Test saving txt file
+		self.song.save_lyrics(filename=filename, format=format)
+		self.assertTrue(os.path.isfile(expected_filename), msg)
+
+		# Test overwriting txt file
+		try:
+			self.song.save_lyrics(filename=filename, format=format, overwrite=True)
+			os.remove(expected_filename)
+		except:
+			self.fail("Failed {} overwrite test".format(format))
+			os.remove(expected_filename)		
+


### PR DESCRIPTION
Closes Issue #11.

You can save an individual `Song` object's lyrics in either `json` or `txt` format:
```python
song = api.search_song('Alright')
song.save_lyrics(format='json');
song.save_lyrics(format='txt');
```

***However***, I'm not too happy with my implementation. The `Song` and `Artist` `save_lyrics()` methods are nearly identical -- way too much repeated code. The tests I wrote are also very similar and will likely pass sometimes when they shouldn't. So, definitely going to need to clean this feature up in the future.