### PR TITLE
Add rate limiting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ To use the Genius API you'll need to sign up for a (free) client that authorizes
 ## Installation
 *LyricsGenius* requires Python 3.
 
-The easiest way to use this package is to install it via [PyPI](https://pypi.python.org/pypi/lyricsgenius) using `pip`:
+The easiest way to start using this package is to install it via [PyPI](https://pypi.python.org/pypi/lyricsgenius) using `pip`:
 
 `$pip install lyricsgenius`
 
 If you'd prefer to clone the repository and install it yourself, follow these steps:
-1. Clone this repo:  
+1. Clone this repo:
 `$git clone https://github.com/johnwmillr/LyricsGenius.git`
-2. Enter the directory created:  
+2. Enter the cloned directory:
 `$cd LyricsGenius`
-3. Install using pip:  
+3. Install using pip:
 `$pip install .`
 
 ## Usage
@@ -63,11 +63,11 @@ $python3 -m lyricsgenius --search-artist 'Lupe Fiasco' 3
 ```
 
 ## Example projects
-  
+
   - [Textual analysis of popular country music](http://www.johnwmillr.com/trucks-and-beer/)
   - [What makes some blink-182 songs more popular than others?](http://jdaytn.com/posts/download-blink-182-data/)
   - [Words per song for rap, rock, and country music](https://www.reddit.com/r/dataisbeautiful/comments/8j1r7b/words_per_song_for_rap_rock_and_country_music_oc/)
-  
+
   I'd love to have more examples to list here! Let me know if you've made use of this wrapper for one of your own projects, and I'll list it here.
 
 ## Contributing

--- a/lyricsgenius/__init__.py
+++ b/lyricsgenius/__init__.py
@@ -8,6 +8,7 @@ __author__ = 'John W. Miller'
 __url__ = 'https://github.com/johnwmillr/GeniusAPI'
 __description__ = 'A Python wrapper around the Genius API'
 __license__ = 'MIT'
+__version__ = '0.6'
 
 import sys
 assert sys.version_info[0] == 3, "LyricsGenius requires Python 3."

--- a/lyricsgenius/__init__.py
+++ b/lyricsgenius/__init__.py
@@ -8,7 +8,7 @@ __author__ = 'John W. Miller'
 __url__ = 'https://github.com/johnwmillr/GeniusAPI'
 __description__ = 'A Python wrapper around the Genius API'
 __license__ = 'MIT'
-__version__ = '0.6'
+__version__ = '0.6.0'
 
 import sys
 assert sys.version_info[0] == 3, "LyricsGenius requires Python 3."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,21 @@
-# http://peterdowns.com/posts/first-time-with-pypi.html
+# LyricsGenius
+# Copyright 2018 John W. Miller
+# See LICENSE for details.
+
+import re
 import os
 from setuptools import find_packages, setup
+
+VERSIONFILE = "lyricsgenius/__init__.py"
+ver_file = open(VERSIONFILE, "rt").read()
+VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+mo = re.search(VSRE, ver_file, re.M)
+
+if mo:
+    version = mo.group(1)
+else:
+    raise RuntimeError(
+        "Unable to find version string in {}".format(VERSIONFILE))
 
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.md')) as f:
@@ -12,24 +27,25 @@ with open('requirements.txt') as f:
 
 setup(
     name='lyricsgenius',
-    version='0.5',
+    version=version,
     description='Download lyrics and metadata from Genius.com',
     long_description=README,
     long_description_content_type="text/markdown",
-    classifiers=[
-        'Programming Language :: Python', # TODO
-    ],
+    license="MIT",
     author='John W. Miller',
     author_email='john.w.millr@gmail.com',
     url='https://github.com/johnwmillr/lyricsgenius',
-    download_url = "https://github.com/johnwmillr/LyricsGenius/archive/0.5.tar.gz",
     keywords='genius api genius-api music lyrics artists albums songs',
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
+    packages=find_packages(exclude=['tests']),
     install_requires=requirements,
     entry_points={
         'console_scripts': [
             'lyricsgenius = lyricsgenius.__main__:main']
     },
+    classifiers=[
+        'Topic :: Software Development :: Libraries',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+    ]
 )

--- a/tests/test_genius.py
+++ b/tests/test_genius.py
@@ -7,169 +7,177 @@ from lyricsgenius.artist import Artist
 # Import client access token from environment variable
 client_access_token = os.environ.get("GENIUS_CLIENT_ACCESS_TOKEN", None)
 assert client_access_token is not None, "Must declare environment variable: GENIUS_CLIENT_ACCESS_TOKEN"
-api = lyricsgenius.Genius(client_access_token)
+api = lyricsgenius.Genius(client_access_token, sleep_time=1)
+
 
 class TestArtist(unittest.TestCase):
 
-	@classmethod
-	def setUpClass(cls):
-		print("\n---------------------\nSetting up Artist tests...\n")
-		cls.artist_name = "The Beatles"
-		cls.new_song = "Paperback Writer"
-		cls.max_songs = 2
-		cls.artist = api.search_artist(cls.artist_name, max_songs=cls.max_songs)
+    @classmethod
+    def setUpClass(cls):
+        print("\n---------------------\nSetting up Artist tests...\n")
+        cls.artist_name = "The Beatles"
+        cls.new_song = "Paperback Writer"
+        cls.max_songs = 2
+        cls.artist = api.search_artist(
+            cls.artist_name, max_songs=cls.max_songs)
 
-	def test_artist(self):
-		msg = "The returned object is not an instance of the Artist class."
-		self.assertIsInstance(self.artist, Artist, msg)
+    def test_artist(self):
+        msg = "The returned object is not an instance of the Artist class."
+        self.assertIsInstance(self.artist, Artist, msg)
 
-	def test_name(self):
-		msg = "The artist object name does not match the requested artist name."
-		self.assertEqual(self.artist.name, self.artist_name, msg)
+    def test_name(self):
+        msg = "The artist object name does not match the requested artist name."
+        self.assertEqual(self.artist.name, self.artist_name, msg)
 
-	def test_add_song_from_same_artist(self):
-		msg = "The new song was not added to the artist object."
-		self.artist.add_song(api.search_song(self.new_song, self.artist_name))
-		self.assertEqual(self.artist.num_songs, self.max_songs+1, msg)
+    def test_add_song_from_same_artist(self):
+        msg = "The new song was not added to the artist object."
+        self.artist.add_song(api.search_song(self.new_song, self.artist_name))
+        self.assertEqual(self.artist.num_songs, self.max_songs+1, msg)
 
-	def test_add_song_from_different_artist(self):
-		msg = "A song from a different artist was incorrectly allowed to be added."
-		self.artist.add_song(api.search_song("These Days","Jackson Browne"))
-		self.assertEqual(self.artist.num_songs, self.max_songs, msg)
+    def test_add_song_from_different_artist(self):
+        msg = "A song from a different artist was incorrectly allowed to be added."
+        self.artist.add_song(api.search_song("These Days", "Jackson Browne"))
+        self.assertEqual(self.artist.num_songs, self.max_songs, msg)
 
-	def test_saving_json_file(self):
-		print('\n')		
-		format = 'json'
-		msg = "Could not save {} file.".format(format)
-		expected_filename = 'tests/lyrics_save_test_file.' + format
-		filename = expected_filename.split('.')[0]
+    def test_saving_json_file(self):
+        print('\n')
+        format = 'json'
+        msg = "Could not save {} file.".format(format)
+        expected_filename = 'tests/lyrics_save_test_file.' + format
+        filename = expected_filename.split('.')[0]
 
-		# Remove the test file if it already exists
-		if os.path.isfile(expected_filename):
-			os.remove(expected_filename)
+        # Remove the test file if it already exists
+        if os.path.isfile(expected_filename):
+            os.remove(expected_filename)
 
-		# Test saving json file
-		self.artist.save_lyrics(filename=filename, format=format)
-		self.assertTrue(os.path.isfile(expected_filename), msg)
+        # Test saving json file
+        self.artist.save_lyrics(filename=filename, format=format)
+        self.assertTrue(os.path.isfile(expected_filename), msg)
 
-		# Test overwriting json file
-		try:
-			self.artist.save_lyrics(filename=filename, format=format, overwrite=True)
-			os.remove(expected_filename)
-		except:
-			self.fail("Failed {} overwrite test".format(format))
-			os.remove(expected_filename)
+        # Test overwriting json file
+        try:
+            self.artist.save_lyrics(
+                filename=filename, format=format, overwrite=True)
+            os.remove(expected_filename)
+        except:
+            self.fail("Failed {} overwrite test".format(format))
+            os.remove(expected_filename)
 
-	def test_saving_txt_file(self):
-		print('\n')
-		format = 'txt'
-		msg = "Could not save {} file.".format(format)
-		expected_filename = 'tests/lyrics_save_test_file.' + format
-		filename = expected_filename.split('.')[0]
+    def test_saving_txt_file(self):
+        print('\n')
+        format = 'txt'
+        msg = "Could not save {} file.".format(format)
+        expected_filename = 'tests/lyrics_save_test_file.' + format
+        filename = expected_filename.split('.')[0]
 
-		# Remove the test file if it already exists
-		if os.path.isfile(expected_filename):
-			os.remove(expected_filename)
+        # Remove the test file if it already exists
+        if os.path.isfile(expected_filename):
+            os.remove(expected_filename)
 
-		# Test saving txt file
-		self.artist.save_lyrics(filename=filename, format=format)
-		self.assertTrue(os.path.isfile(expected_filename), msg)
+        # Test saving txt file
+        self.artist.save_lyrics(filename=filename, format=format)
+        self.assertTrue(os.path.isfile(expected_filename), msg)
 
-		# Test overwriting txt file
-		try:
-			self.artist.save_lyrics(filename=filename, format=format, overwrite=True)
-			os.remove(expected_filename)
-		except:
-			self.fail("Failed {} overwrite test".format(format))
-			os.remove(expected_filename)
+        # Test overwriting txt file
+        try:
+            self.artist.save_lyrics(
+                filename=filename, format=format, overwrite=True)
+            os.remove(expected_filename)
+        except:
+            self.fail("Failed {} overwrite test".format(format))
+            os.remove(expected_filename)
+
 
 class TestSong(unittest.TestCase):
 
-	@classmethod
-	def setUpClass(cls):
-		print("\n---------------------\nSetting up Song tests...\n")
-		cls.artist_name = 'Andy Shauf'
-		cls.song_title = 'begin again' # Lowercase is intentional
-		cls.album = 'The Party'
-		cls.year = '2016-05-20'
-		cls.song = api.search_song(cls.song_title, cls.artist_name)
-		cls.song_trimmed = api.search_song(cls.song_title, cls.artist_name, remove_section_headers=True)
+    @classmethod
+    def setUpClass(cls):
+        print("\n---------------------\nSetting up Song tests...\n")
+        cls.artist_name = 'Andy Shauf'
+        cls.song_title = 'begin again'  # Lowercase is intentional
+        cls.album = 'The Party'
+        cls.year = '2016-05-20'
+        cls.song = api.search_song(cls.song_title, cls.artist_name)
+        cls.song_trimmed = api.search_song(
+            cls.song_title, cls.artist_name, remove_section_headers=True)
 
-	def test_song(self):
-		msg = "The returned object is not an instance of the Song class."
-		self.assertIsInstance(self.song, Song, msg)
+    def test_song(self):
+        msg = "The returned object is not an instance of the Song class."
+        self.assertIsInstance(self.song, Song, msg)
 
-	def test_title(self):
-		msg = "The returned song title does not match the title of the requested song."
-		self.assertEqual(api._clean_str(self.song.title), api._clean_str(self.song_title), msg)
+    def test_title(self):
+        msg = "The returned song title does not match the title of the requested song."
+        self.assertEqual(api._clean_str(self.song.title),
+                         api._clean_str(self.song_title), msg)
 
-	def test_artist(self):
-		msg = "The returned artist name does not match the artist of the requested song."
-		self.assertEqual(self.song.artist, self.artist_name)
+    def test_artist(self):
+        msg = "The returned artist name does not match the artist of the requested song."
+        self.assertEqual(self.song.artist, self.artist_name)
 
-	def test_album(self):
-		msg = "The returned album name does not match the album of the requested song."
-		self.assertEqual(self.song.album, self.album, msg)
+    def test_album(self):
+        msg = "The returned album name does not match the album of the requested song."
+        self.assertEqual(self.song.album, self.album, msg)
 
-	def test_year(self):
-		msg = "The returned year does not match the year of the requested song"
-		self.assertEqual(self.song.year, self.year, msg)
+    def test_year(self):
+        msg = "The returned year does not match the year of the requested song"
+        self.assertEqual(self.song.year, self.year, msg)
 
-	def test_lyrics_raw(self):
-		lyrics = '[Verse 1: Andy Shauf]'
-		self.assertTrue(self.song.lyrics.startswith(lyrics))
+    def test_lyrics_raw(self):
+        lyrics = '[Verse 1: Andy Shauf]'
+        self.assertTrue(self.song.lyrics.startswith(lyrics))
 
-	def test_lyrics_no_section_headers(self):
-		lyrics = 'Begin again\nThis time you should take a bow at the'
-		self.assertTrue(self.song_trimmed.lyrics.startswith(lyrics))		
+    def test_lyrics_no_section_headers(self):
+        lyrics = 'Begin again\nThis time you should take a bow at the'
+        self.assertTrue(self.song_trimmed.lyrics.startswith(lyrics))
 
-	def test_media(self):
-		msg = "The returned song does not have a media attribute."
-		self.assertTrue(hasattr(self.song, 'media'), msg)
+    def test_media(self):
+        msg = "The returned song does not have a media attribute."
+        self.assertTrue(hasattr(self.song, 'media'), msg)
 
-	def test_saving_json_file(self):
-		print('\n')		
-		format = 'json'
-		msg = "Could not save {} file.".format(format)
-		expected_filename = 'tests/lyrics_save_test_file.' + format
-		filename = expected_filename.split('.')[0]
+    def test_saving_json_file(self):
+        print('\n')
+        format = 'json'
+        msg = "Could not save {} file.".format(format)
+        expected_filename = 'tests/lyrics_save_test_file.' + format
+        filename = expected_filename.split('.')[0]
 
-		# Remove the test file if it already exists
-		if os.path.isfile(expected_filename):
-			os.remove(expected_filename)
+        # Remove the test file if it already exists
+        if os.path.isfile(expected_filename):
+            os.remove(expected_filename)
 
-		# Test saving json file
-		self.song.save_lyrics(filename=filename, format=format)
-		self.assertTrue(os.path.isfile(expected_filename), msg)
+        # Test saving json file
+        self.song.save_lyrics(filename=filename, format=format)
+        self.assertTrue(os.path.isfile(expected_filename), msg)
 
-		# Test overwriting json file
-		try:
-			self.song.save_lyrics(filename=filename, format=format, overwrite=True)
-			os.remove(expected_filename)
-		except:
-			self.fail("Failed {} overwrite test".format(format))
-			os.remove(expected_filename)
+        # Test overwriting json file
+        try:
+            self.song.save_lyrics(
+                filename=filename, format=format, overwrite=True)
+            os.remove(expected_filename)
+        except:
+            self.fail("Failed {} overwrite test".format(format))
+            os.remove(expected_filename)
 
-	def test_saving_txt_file(self):
-		print('\n')
-		format = 'txt'
-		msg = "Could not save {} file.".format(format)
-		expected_filename = 'tests/lyrics_save_test_file.' + format
-		filename = expected_filename.split('.')[0]
+    def test_saving_txt_file(self):
+        print('\n')
+        format = 'txt'
+        msg = "Could not save {} file.".format(format)
+        expected_filename = 'tests/lyrics_save_test_file.' + format
+        filename = expected_filename.split('.')[0]
 
-		# Remove the test file if it already exists
-		if os.path.isfile(expected_filename):
-			os.remove(expected_filename)
+        # Remove the test file if it already exists
+        if os.path.isfile(expected_filename):
+            os.remove(expected_filename)
 
-		# Test saving txt file
-		self.song.save_lyrics(filename=filename, format=format)
-		self.assertTrue(os.path.isfile(expected_filename), msg)
+        # Test saving txt file
+        self.song.save_lyrics(filename=filename, format=format)
+        self.assertTrue(os.path.isfile(expected_filename), msg)
 
-		# Test overwriting txt file
-		try:
-			self.song.save_lyrics(filename=filename, format=format, overwrite=True)
-			os.remove(expected_filename)
-		except:
-			self.fail("Failed {} overwrite test".format(format))
-			os.remove(expected_filename)		
-
+        # Test overwriting txt file
+        try:
+            self.song.save_lyrics(
+                filename=filename, format=format, overwrite=True)
+            os.remove(expected_filename)
+        except:
+            self.fail("Failed {} overwrite test".format(format))
+            os.remove(expected_filename)


### PR DESCRIPTION
This PR closes issue #32 by adding a `time.sleep()` statement within the `_make_api_request()` function.

User is able to specify length of wait time (in seconds) when creating the initial instance of the `Genius` class:
```python
api = lyricsgenius.Genius(client_access_token, sleep_time=1)
```

A better solution would be to implement some sort of global awareness of the frequency of calls to the Genius API server.