### PR TITLE
Improve _result_is_lyrics method

### DIFF
--- a/lyricsgenius/api.py
+++ b/lyricsgenius/api.py
@@ -138,17 +138,18 @@ class Genius(API):
     def _clean_str(self, s):
         return s.translate(str.maketrans('', '', punctuation)).replace('\u200b', " ").strip().lower()
 
-    def _result_is_lyrics(self, song_title, extra_terms=[]):
+    def _result_is_lyrics(self, song_title, extra_terms=[],
+                          replace_defaults=False):
         """Returns False if result from Genius is not actually song lyrics"""
 
         excluded_terms = ['track\\s?list', 'album art(work)?', 'liner notes',
-                          'booklet', 'credits', 'interview',
-                          'skit', 'instrumental']
+                          'booklet', 'credits', 'interview', 'skit',
+                          'instrumental']
         if extra_terms:
-            if isinstance(extra_terms, list):
-                excluded_terms.extend(extra_terms)
+            if replace_defaults:
+                excluded_terms = extra_terms
             else:
-                excluded_terms.append(extra_terms)
+                excluded_terms.extend(extra_terms if isinstance(extra_terms, list) else [extra_terms])
 
         expression = r"".join(["({})|".format(term) for term in excluded_terms]).strip('|')
         regex = re.compile(expression, re.IGNORECASE)

--- a/lyricsgenius/api.py
+++ b/lyricsgenius/api.py
@@ -24,9 +24,9 @@ class API(object):
     """Genius API"""
 
     # Create a persistent requests connection
-    userAgent = 'LyricsGenius'
     session = requests.Session()
-    session.headers = {'application': userAgent, 'User-Agent': userAgent}
+    session.headers = {'application': 'LyricsGenius',
+                       'User-Agent': 'https://github.com/johnwmillr/LyricsGenius'}
 
     def __init__(self, client_access_token,
                  response_format='plain', timeout=5, sleep_time=0.5):
@@ -138,10 +138,20 @@ class Genius(API):
     def _clean_str(self, s):
         return s.translate(str.maketrans('', '', punctuation)).replace('\u200b', " ").strip().lower()
 
-    def _result_is_lyrics(self, song_title):
+    def _result_is_lyrics(self, song_title, extra_terms=[]):
         """Returns False if result from Genius is not actually song lyrics"""
-        regex = re.compile(
-            r"(tracklist)|(track list)|(album art(work)?)|(liner notes)|(booklet)|(credits)|(remix)|(interview)|(skit)", re.IGNORECASE)
+
+        excluded_terms = ['track\\s?list', 'album art(work)?', 'liner notes',
+                          'booklet', 'credits', 'interview',
+                          'skit', 'instrumental']
+        if extra_terms:
+            if isinstance(extra_terms, list):
+                excluded_terms.extend(extra_terms)
+            else:
+                excluded_terms.append(extra_terms)
+
+        expression = r"".join(["({})|".format(term) for term in excluded_terms]).strip('|')
+        regex = re.compile(expression, re.IGNORECASE)
         return not regex.search(song_title)
 
     def search_song(self, song_title, artist_name=""):

--- a/lyricsgenius/api.py
+++ b/lyricsgenius/api.py
@@ -140,7 +140,12 @@ class Genius(API):
 
     def _result_is_lyrics(self, song_title, extra_terms=[],
                           replace_defaults=False):
-        """Returns False if result from Genius is not actually song lyrics"""
+        """Returns False if result from Genius is not actually song lyrics
+
+        :param song_title: title of the song, used to check for non-lyrics
+        :param extra_terms: (list) extra terms for flagging non-lyrics
+        :param replace_defaults: if True, replaces default terms with user's
+        """
 
         excluded_terms = ['track\\s?list', 'album art(work)?', 'liner notes',
                           'booklet', 'credits', 'interview', 'skit',
@@ -149,7 +154,7 @@ class Genius(API):
             if replace_defaults:
                 excluded_terms = extra_terms
             else:
-                excluded_terms.extend(extra_terms if isinstance(extra_terms, list) else [extra_terms])
+                excluded_terms.extend(extra_terms)
 
         expression = r"".join(["({})|".format(term) for term in excluded_terms]).strip('|')
         regex = re.compile(expression, re.IGNORECASE)

--- a/tests/test_genius.py
+++ b/tests/test_genius.py
@@ -134,6 +134,10 @@ class TestSong(unittest.TestCase):
         msg = "The returned song does not have a media attribute."
         self.assertTrue(hasattr(self.song, 'media'), msg)
 
+    def test_result_is_lyrics(self):
+        msg = "Did not reject a false-song."
+        self.assertFalse(api._result_is_lyrics('Beatles Tracklist'), msg)
+
     def test_saving_json_file(self):
         print('\n')
         format_ = 'json'


### PR DESCRIPTION
This PR closes #46 by adding an option for the user to specify additional terms to be used for flagging songs as non-songs. The user can either append their terms to the default list (default behavior) or replace the terms by setting `replace_defaults` to `True`.

However, the implementation is not yet suitable for incorporation with `master`. The `_result_is_lyrics` method is called by the `search_` functions and is not directly accessible by the user. I could make the `extra_terms` parameter an instance variable of the `Genius` class, but this would be confusing for the user. Needs some thought.

