### PR TITLE
Removes tmp_dir at the end of Genius.save_artists

### DIFF
--- a/lyricsgenius/api.py
+++ b/lyricsgenius/api.py
@@ -9,6 +9,7 @@ API documentation: https://docs.genius.com/
 import os
 import re
 import requests
+import shutil
 import socket
 import json
 from bs4 import BeautifulSoup
@@ -373,6 +374,9 @@ class Genius(API):
         # Save all of the lyrics
         with open(filename + '.json', 'w') as outfile:
             json.dump(all_lyrics, outfile)
+
+        # Delete the temporary directory
+        shutil.rmtree(tmp_dir)
 
         end = time.time()
         print("Time elapsed: {} hours".format((end-start)/60.0/60.0))


### PR DESCRIPTION
After saving the lyrics in JSON files inside to the users selected directory, the tmp_dir (`./tmp_lyrics`), is removed.

Note: this is my first PR so please let me know if there's anything missing!