### PR TITLE
Address the requests vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 beautifulsoup4==4.6.0
-requests==2.18.1
+requests>=2.20.0


### PR DESCRIPTION
GitHub identified a bug in older versions of `requests`. This PR addresses the bug by requiring versions of requests equal to or newer than `2.20.0`.