### PR TITLE
Use argparse for command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ pip install git+https://github.com/johnwmillr/LyricsGenius.git
 Import the package and search for songs by a given artist:
 
 ```python
-lyricsgenius as genius
-api = genius.Genius('my_client_access_token_here')
-artist = api.search_artist('Andy Shauf', max_songs=3)
+import lyricsgenius as genius
+api = genius.Genius("my_client_access_token_here")
+artist = api.search_artist("Andy Shauf", max_songs=3)
 ```
 
 Search for a single song by the same artist:
 
 ```python
-song = api.search_song('To You', artist.name)
+song = api.search_song("To You", artist.name)
 ```
 
 Add the song to the artist object:
@@ -54,8 +54,19 @@ You can also call the package from the command line:
 
 ```bash
 export GENIUS_CLIENT_ACCESS_TOKEN="my_client_access_token_here"
-python3 -m lyricsgenius --search-song 'Begin Again' 'Andy Shauf'
-python3 -m lyricsgenius --search-artist 'Lupe Fiasco' 3
+python3 -m lyricsgenius --help
+```
+
+Search for and save lyrics to a given song:
+
+```bash
+python3 -m lyricsgenius song "Begin Again" "Andy Shauf" --save
+```
+
+Search for five songs by 'The Beatles' and save the lyrics:
+
+```bash
+python3 -m lyricsgenius artist "The Beatles" --max-songs 5 --save
 ```
 
 ## Example projects

--- a/lyricsgenius/__init__.py
+++ b/lyricsgenius/__init__.py
@@ -8,7 +8,7 @@ __author__ = 'John W. Miller'
 __url__ = 'https://github.com/johnwmillr/LyricsGenius'
 __description__ = 'A Python wrapper around the Genius API'
 __license__ = 'MIT'
-__version__ = '0.9.8'
+__version__ = '0.9.9'
 
 import sys
 assert sys.version_info[0] == 3, "LyricsGenius requires Python 3."

--- a/lyricsgenius/__main__.py
+++ b/lyricsgenius/__main__.py
@@ -1,37 +1,57 @@
 #  Command line usage:
-#    $python3 -m lyricsgenius --search-song 'Begin Again' 'Andy Shauf'
-#    $python3 -m lyricsgenius --search-artist 'Lupe Fiasco' 3
+#    python3 -m lyricsgenius --help
+#    python3 -m lyricsgenius song "Begin Again" "Andy Shauf" --save
+#    python3 -m lyricsgenius artist "The Beatles" --max-songs 5 --save
 
-import sys
 import os
-import lyricsgenius as genius
+import argparse
+import lyricsgenius
+
 
 def main(args=None):
-    if args is None:
-        args = sys.argv[1:]
-    
+    msg = "Download song lyrics from Genius.com"
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument("search_type", type=str.lower, choices=["song", "artist"],
+                        help="Specify whether search is for 'song' or 'artist'")
+    parser.add_argument("terms", type=str, nargs="+",
+                        help="Provide terms for search")
+    parser.add_argument("--save", action="store_true",
+                        help="If specified, saves songs to JSON file")
+    parser.add_argument("--max-songs", type=int,
+                        help="Specify number of songs when searching for artist")
+    parser.add_argument("-q", "--quiet", action="store_true",
+                        help="Turn off the API verbosity")
+    args = parser.parse_args()
+
+    # Create an instance of the Genius class
     client_access_token = os.environ.get("GENIUS_CLIENT_ACCESS_TOKEN", None)
-    assert client_access_token is not None, "Must declare environment variable: GENIUS_CLIENT_ACCESS_TOKEN"
-    api = genius.Genius(client_access_token)
-                
-    # There must be a standard way to handle "--" inputs on the command line
-    if sys.argv[1] == '--search-song':            
-        if len(sys.argv) == 4:                        
-            song = api.search_song(sys.argv[2],sys.argv[3])
-        elif len(sys.argv) == 3:
-            song = api.search_song(sys.argv[2])                                
-        print('"{title}" by {artist}:\n    {lyrics}'.format(title=song.title,artist=song.artist,lyrics=song.lyrics.replace('\n','\n    ')))        
-    elif sys.argv[1] == '--search-artist':
-        if len(sys.argv) == 4:
-            max_songs = int(sys.argv[3])
-        else:
-            max_songs = 5
-        artist = api.search_artist(sys.argv[2], max_songs=max_songs)
-        print("Saving {} lyrics...".format(artist.name))
-        api.save_artist_lyrics(artist)
+    msg = "Must declare environment variable: GENIUS_CLIENT_ACCESS_TOKEN"
+    assert client_access_token, msg
+    api = lyricsgenius.Genius(client_access_token)
+    if args.quiet:
+        api.verbose = False
+
+    # Handle the command-line inputs
+    if args.search_type == "song":
+        song = api.search_song(*args.terms)
+        if not song:
+            if not args.quiet:
+                print("Could not find specified song. Check spelling?")
+            return
+        print('\n"{s}" by {a}:\n\n{lyrics}\n'.format(s=song.title,
+                                                     a=song.artist,
+                                                     lyrics=song.lyrics))
+        if args.save:
+            if not args.quiet:
+                print("Saving lyrics to '{s}'...".format(s=song.title))
+        song.save_lyrics()
     else:
-        print("Usage: python -m lyricsgenius [--search-song song_name] [--search-artist artist_name num_songs]")
-        return
+        artist = api.search_artist(args.terms[0], max_songs=args.max_songs)
+        if args.save:
+            if not args.quiet:
+                print("Saving '{a}'' lyrics...".format(a=artist.name))
+            api.save_artists(artist)
+
 
 if __name__ == "__main__":
     main()

--- a/lyricsgenius/api.py
+++ b/lyricsgenius/api.py
@@ -246,7 +246,7 @@ class Genius(API):
             return song
 
         if self.verbose:
-            print("Could not find specified song.")
+            print("Could not find specified song. Check spelling?")
         return None
 
     def search_artist(self, artist_name, max_songs=None, sort='title',


### PR DESCRIPTION
This PR resolves #53.

Instead of using my ad-hoc method of `sys.args`, this code uses Python's built-in `argparse` module. The `README` has been updated to reflect the new CLI usage.