### PR TITLE
Change self.artist to self.name in Artist.save_lyrics

### DIFF
--- a/lyricsgenius/artist.py
+++ b/lyricsgenius/artist.py
@@ -106,7 +106,7 @@ class Artist(object):
                 filename = filename.replace("." + ext, "")
             filename += "." + format_
         else:
-            filename = "Lyrics_{}.{}".format(self.artist.replace(" ", ""), format_)
+            filename = "Lyrics_{}.{}".format(self.name.replace(" ", ""), format_)
 
         # Check if file already exists
         write_file = False


### PR DESCRIPTION
Resolves #71.

The `Artist.save_lyrics` method is failing because the method is incorrectly attempting to access the `artist` field of the `Artist` object. The correct field is `name`.