### PR TITLE
Add assertion requiring python3 in setup.py

### DIFF
--- a/lyricsgenius/__init__.py
+++ b/lyricsgenius/__init__.py
@@ -8,7 +8,7 @@ __author__ = 'John W. Miller'
 __url__ = 'https://github.com/johnwmillr/LyricsGenius'
 __description__ = 'A Python wrapper around the Genius API'
 __license__ = 'MIT'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 import sys
 assert sys.version_info[0] == 3, "LyricsGenius requires Python 3."

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,12 @@
 # Copyright 2018 John W. Miller
 # See LICENSE for details.
 
+import sys
 import re
 from os import path
 from setuptools import find_packages, setup
+
+assert sys.version_info[0] == 3, "LyricsGenius requires Python 3."
 
 VERSIONFILE = "lyricsgenius/__init__.py"
 ver_file = open(VERSIONFILE, "rt").read()


### PR DESCRIPTION
Closes #74.

Per the above issue, installation fails without explanation when a user tries to install `lyricsgenius` using pip with Python 2.x. This PR adds an assertion test to `setup.py` that checks for Python 3.x. The install will still fail for Python 2.x (as I'd like it to), but the user will now see an informative error message.