### PR TITLE
Added utf-8 encoding when saving a file

### DIFF
--- a/lyricsgenius/api.py
+++ b/lyricsgenius/api.py
@@ -391,8 +391,8 @@ class Genius(API):
                 all_lyrics['artists'][-1] = artist.save_lyrics(overwrite=True)
 
         # Save all of the lyrics
-        with open(filename + '.json', 'w') as outfile:
-            json.dump(all_lyrics, outfile)
+        with open(filename + '.json', 'w', encoding='utf-8') as outfile:
+            json.dump(all_lyrics, outfile, ensure_ascii=False)
 
         # Delete the temporary directory
         shutil.rmtree(tmp_dir)

--- a/lyricsgenius/song.py
+++ b/lyricsgenius/song.py
@@ -140,7 +140,7 @@ class Song(object):
 
         # Write the lyrics to either a .json or .txt file
         if write_file:
-            with open(filename, 'wb' if binary_encoding else 'w') as lyrics_file:
+            with open(filename, 'wb' if binary_encoding else 'w', encoding='utf-8') as lyrics_file:
                 if extension == 'json':
                     json.dump(lyrics_to_write, lyrics_file)
                 else:

--- a/lyricsgenius/song.py
+++ b/lyricsgenius/song.py
@@ -142,7 +142,7 @@ class Song(object):
         if write_file:
             with open(filename, 'wb' if binary_encoding else 'w', encoding='utf-8') as lyrics_file:
                 if extension == 'json':
-                    json.dump(lyrics_to_write, lyrics_file)
+                    json.dump(lyrics_to_write, lyrics_file, ensure_ascii=False)
                 else:
                     lyrics_file.write(lyrics_to_write)
             if verbose:


### PR DESCRIPTION
Specifying a custom file name in order to save a song can produce an error when the name contains umlauts.
Using "utf-8" as file encoding fixes the error.