### PR TITLE
Download no songs when 0 max_songs is specified

### DIFF
--- a/lyricsgenius/api.py
+++ b/lyricsgenius/api.py
@@ -336,7 +336,7 @@ class Genius(API):
         artist = Artist(artist_info)
         # Download each song by artist, stored as Song objects in Artist object
         page = 1
-        reached_max_songs = False
+        reached_max_songs = True if max_songs == 0 else False
         while not reached_max_songs:
             songs_on_page = self.get_artist_songs(artist_id, sort, per_page, page)
         

--- a/tests/test_genius.py
+++ b/tests/test_genius.py
@@ -105,6 +105,12 @@ class TestArtist(unittest.TestCase):
         result = genius.search_artist(name, max_songs=1).name
         self.assertEqual(name, result, msg)
 
+    def test_zero_songs(self):
+        msg = "Songs were downloaded even though 0 songs was requested."
+        name = "Queen"
+        result = genius.search_artist(name, max_songs=0).songs
+        self.assertEqual(0, len(result), msg)
+
     def test_name(self):
         msg = "The artist object name does not match the requested artist name."
         self.assertEqual(self.artist.name, self.artist_name, msg)


### PR DESCRIPTION
Don't download any songs when the argument `max_songs` is passed as 0 in `Genius.search_artist`