### PR TITLE
Fix initiating OAuth2 InvalidTokenError

### DIFF
--- a/lyricsgenius/auth.py
+++ b/lyricsgenius/auth.py
@@ -32,7 +32,7 @@ class OAuth2(Sender):
     def __init__(self, client_id, redirect_uri,
                  client_secret=None, scope=None,
                  state=None, client_only_app=False):
-        super().__init__()
+        super().__init__(public_api_constructor=True)
         msg = ("You must provide a client_secret "
                "if you intend to use the full code exchange."
                "\nIf you meant to use the client-only flow, "


### PR DESCRIPTION
Since OAuth2 inherits Sender and calls its `__init__`, if the user doesn't have the `GENIUS_ACCESS_TOKEN` env var present, they'll get an `InvalidTokenErro`. This temporary fix which also worked for `PublicAPI` will work for now until we refactor the classes and make the sender an attribute instead of inheriting it.