### PR TITLE
Migrate tests to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{matrix.python-version}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python-version}}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+    - name: Run tox
+      env:
+        GENIUS_ACCESS_TOKEN: ${{ secrets.GENIUS_ACCESS_TOKEN }}
+        GENIUS_CLIENT_ID: ${{ secrets.GENIUS_CLIENT_ID }}
+        GENIUS_CLIENT_SECRET: ${{ secrets.GENIUS_CLIENT_SECRET }}
+        GENIUS_REDIRECT_URI: ${{ secrets.GENIUS_REDIRECT_URI }}
+      run: tox

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,4 +19,5 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[docs]
     - name: Build Docs
-      run: tox -e docs
+      working-directory: ./docs
+      run: sphinx-build -W -b html src build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: docs
+
+on:
+  pull_request:
+
+jobs:
+  docs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[docs]
+    - name: Build Docs
+      run: tox -e docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[checks]
+    - name: Lint
+      run: tox -e lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: python
-
-install: pip install .[dev]
-
-script: tox

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -2,7 +2,7 @@
 .. image:: header.png
 
 
-LyricsGenius: Python client for the Genius.com API
+LyricsGenius: a Python client for the Genius.com API
 ====================================================
 .. image:: https://travis-ci.org/johnwmillr/LyricsGenius.svg?branch=master
    :target: https://travis-ci.org/johnwmillr/LyricsGenius

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -2,7 +2,7 @@
 .. image:: header.png
 
 
-LyricsGenius: a Python client for the Genius.com API
+LyricsGenius: Python client for the Genius.com API
 ====================================================
 .. image:: https://travis-ci.org/johnwmillr/LyricsGenius.svg?branch=master
    :target: https://travis-ci.org/johnwmillr/LyricsGenius
@@ -83,6 +83,11 @@ to :ref:`setup` to get started.
    :caption: Misc
 
    contributing
+
+.. toctree::
+   :hidden:
+
+   404.rst
 
 .. _Genius.com: https://www.genius.com
 .. _“Words are flowing out like endless rain into a paper cup”:

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ description = Build Sphinx HTML documentation
 extras = docs
 changedir = docs
 allowlist_externals = sphinx-build
-commands = sphinx-build -b html src build
+commands = sphinx-build -W -b html src build
 
 [testenv:doc8]
 description = Check documentation .rst files


### PR DESCRIPTION
It's best that the tests run using GitHub Actions instead of Travis CI. This PR makes the following changes:
- Removed `travis.yml`.
- Added `lint.yml` and `docs.yml` for lint tests and building docs for PRs.
- Added `build.yml` that runs all tox tests on various Python versions for pushes to master and PRs (the badge generated by this job replaces the current one).
- Treat warnings from doc build as errors.
- Fixed `404.rst isn't part of any doctree` warning to avoid recognizing current docs builds as failed.