### PR TITLE
Added threading to search methods

### DIFF
--- a/lyricsgenius/__main__.py
+++ b/lyricsgenius/__main__.py
@@ -27,6 +27,8 @@ def main(args=None):
                         help="Specify number of songs when searching for artist")
     parser.add_argument("-q", "--quiet", action="store_true",
                         help="Turn off the API verbosity")
+    parser.add_argument("-n", "--num-workers", type=int, default=1,
+                        help="Number of threads used to get songs")
     args = parser.parse_args()
 
     # Create an instance of the Genius class
@@ -51,7 +53,8 @@ def main(args=None):
     elif args.search_type == "artist":
         artist = api.search_artist(args.terms[0],
                                    max_songs=args.max_songs,
-                                   sort='popularity')
+                                   sort='popularity',
+                                   num_workers=args.num_workers)
         if args.save:
             if not args.quiet:
                 print("Saving '{a}'' lyrics...".format(a=safe_unicode(artist.name)))

--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -365,9 +365,11 @@ class Genius(API, PublicAPI):
             next_page = tracks_list['next_page']
         for thread in thread_pool:
             thread.join()
+
+        length = len(tracks)
         tracks.sort(key=lambda track: (track.number
                                        if track.number is not None
-                                       else len(tracks) + 1))
+                                       else length))
 
         if album_id is None and get_full_info is True:
             new_info = self.album(album_id, text_format=text_format)['album']

--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -582,14 +582,16 @@ class Genius(API, PublicAPI):
                                               )
             thread_pool = []
             for song in songs_on_page["songs"]:
-                thread = threading.Thread(target=download_song, args=(song,))
-                thread.start()
-                thread_pool.append(thread)
-
-                if len(thread_pool) == num_workers:
-                    for thread in thread_pool:
-                        thread.join()
-                    thread_pool.clear()
+                if num_workers != 1:
+                    thread = threading.Thread(target=download_song, args=(song,))
+                    thread.start()
+                    thread_pool.append(thread)
+                    if len(thread_pool) == num_workers:
+                        for thread in thread_pool:
+                            thread.join()
+                        thread_pool.clear()
+                else:
+                    download_song(song)
 
                 num_songs += 1
                 # Exit search if the max number of songs has been met

--- a/lyricsgenius/types/album.py
+++ b/lyricsgenius/types/album.py
@@ -126,4 +126,7 @@ class Track(BaseEntity):
 
     def __repr__(self):
         name = self.__class__.__name__
-        return "{}(number, song)".format(name)
+        return "{name}({number}, {song})".format(
+            name=name,
+            number=self.number,
+            song=repr(self.song))

--- a/lyricsgenius/types/album.py
+++ b/lyricsgenius/types/album.py
@@ -126,7 +126,7 @@ class Track(BaseEntity):
 
     def __repr__(self):
         name = self.__class__.__name__
-        return "{name}({number}, {song})".format(
+        return "{name}({number}, Song(id={song_id}))".format(
             name=name,
             number=self.number,
-            song=repr(self.song))
+            song_id=self.song.id)

--- a/lyricsgenius/types/artist.py
+++ b/lyricsgenius/types/artist.py
@@ -18,7 +18,6 @@ class Artist(BaseEntity):
         self._body = body
         self._client = client
         self.songs = []
-        self.num_songs = len(self.songs)
 
         self.api_path = body['api_path']
         self.header_image_url = body['header_image_url']
@@ -76,7 +75,6 @@ class Artist(BaseEntity):
         if (new_song.artist == self.name
                 or (include_features and any(new_song._body['featured_artists']))):
             self.songs.append(new_song)
-            self.num_songs += 1
             return new_song
         if verbose:
             print("Can't add song by {b}, artist must be {a}.".format(
@@ -149,6 +147,7 @@ class Artist(BaseEntity):
 
     def __str__(self):
         """Return a string representation of the Artist object."""
-        msg = "{name}, {num} songs".format(name=self.name, num=self.num_songs)
-        msg = msg[:-1] if self.num_songs == 1 else msg
+        num_songs = len(self.songs)
+        msg = "{name}, {num} songs".format(name=self.name, num=num_songs)
+        msg = msg[:-1] if num_songs == 1 else msg
         return msg

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -41,7 +41,7 @@ class TestArtist(unittest.TestCase):
     def test_add_song_from_same_artist(self):
         msg = "The new song was not added to the artist object."
         self.artist.add_song(genius.search_song(self.new_song, self.artist_name))
-        self.assertEqual(self.artist.num_songs, self.max_songs + 1, msg)
+        self.assertEqual(len(self.artist.songs), self.max_songs + 1, msg)
 
     def test_song(self):
         msg = "Song was not in artist's songs."
@@ -51,7 +51,7 @@ class TestArtist(unittest.TestCase):
     def test_add_song_from_different_artist(self):
         msg = "A song from a different artist was incorrectly allowed to be added."
         self.artist.add_song(genius.search_song("These Days", "Jackson Browne"))
-        self.assertEqual(self.artist.num_songs, self.max_songs, msg)
+        self.assertEqual(len(self.artist.songs), self.max_songs, msg)
 
     def test_artist_with_includes_features(self):
         # The artist did not get songs returned that they were featured in.


### PR DESCRIPTION
The `search_album` and `search_artist` methods could definitely benefit from threading. I added the `num_workers` parameter for the user to define the number of threads used. If the user just used the default `num_workers=1`, no threading is used and the songs are downloaded like they were before.
As for thread safety:
- Python lists are inherently thread-safe and we just add the created songs to the list. So I don't see any issues with `artist.songs`.
- The `artist.num_songs` attribute isn't thread-safe and we'd need to set setter/getters and a `threading.lock` if we wanted to keep that attribute. Instead, I removed it and substituted it with `len(artist.songs)`.
- The `requests.Session` object is not thread-safe and it's [recommended](https://stackoverflow.com/questions/18188044/is-the-session-object-from-pythons-requests-library-thread-safe) to use one Session per thread. But considering that we don't modify the Session at all in this solution, I don't think that'll be a problem. Although it needs a little more investigation. 