### PR TITLE
Add Pre-Commit Config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    -   id: flake8
+        additional_dependencies: [flake8-bugbear==21.4.3]
+        args:
+        - --ignore=B305,B950,E402,E501,E722,F401,W503
+        - --select=C,E,F,W,B,B9
+        - --max-line-length=88
+-   repo: https://github.com/pycqa/doc8
+    rev: 0.8.1
+    hooks:
+    -   id: doc8
+        args:
+        - docs/src

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ extras_require = {
     ],
     'checks': [
         'tox~=3.2',
-        'doc8',
-        'flake8',
-        'flake8-bugbear',
+        'doc8==0.8.1',
+        'flake8==3.8.4',
+        'flake8-bugbear==21.4.3',
         'pygments',
     ]
 }


### PR DESCRIPTION
[Pre-commit](https://pre-commit.com/) is an easy and straightforward way to run our checks before letting the commit go through. It's really useful to catch simple mistakes and then having to make another commit to fix those mistakes.
This pre-commit config creates hooks for `flake8` and `doc8`. We could possibly create hooks for creating docs or even running the unit tests, but since those tests take some time, it's better to leave them out.

After #199 is merged, we should update the contributing guidelines in this PR to mention the config and then merge it.