### PR TITLE
fix lyrics search

### DIFF
--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -208,10 +208,10 @@ class Genius(API, PublicAPI):
         sections = sorted(response['sections'],
                           key=lambda sect: sect['type'] == type_)
 
-        hits = [hit for hit in top_hits if hit['type'] == type_]
+        hits = [hit for hit in top_hits if hit['index'] == type_]
         hits.extend([hit for section in sections
                      for hit in section['hits']
-                     if hit['type'] == type_])
+                     if hit['index'] == type_])
 
         for hit in hits:
             item = hit['result']


### PR DESCRIPTION
Lyrics search sometimes returns a spotify track listing item, instead of the actual song

Example input:
genius.search_song("a$ap forever (feat. moby)", "a$ap rocky")

Lyrics ouput: a list of tracks from "New Music Friday 04/06/18 by Spotify"

These changes fix this issue by finding the correct hit in the search results, ignoring hits with index = "lyric", instead with index = "song"