### PR TITLE
fix: iterate over results pages when searching for artist

### DIFF
--- a/lyricsgenius/api/public_methods/search.py
+++ b/lyricsgenius/api/public_methods/search.py
@@ -7,7 +7,7 @@ class SearchMethods(object):
         Args:
             search_term (:obj:`str`): A term to search on Genius.
             per_page (:obj:`int`, optional): Number of results to
-                return per request. It can't be more than 50.
+                return per request. It can't be more than 5.
             page (:obj:`int`, optional): Paginated offset (number of the page).
             text_format (:obj:`str`, optional): Text format of the results
                 ('dom', 'html', 'markdown' or 'plain').

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -34,6 +34,12 @@ class TestArtist(unittest.TestCase):
         result = genius.search_artist(name, max_songs=0).songs
         self.assertEqual(0, len(result), msg)
 
+    def test_search_artist_not_on_the_first_results_page(self):
+        msg = "Different artist was returned."
+        name = "Norther"
+        result = genius.search_artist(name, max_songs=self.max_songs)
+        self.assertEqual(name, result.name, msg)
+
     def test_name(self):
         msg = "The artist object name does not match the requested artist name."
         self.assertEqual(self.artist.name, self.artist_name, msg)


### PR DESCRIPTION
**Problem**

When searching for a specific artist by name it currently requests 3 results per page per section (default value), not iterating over the next pages. 
In this example it happens that the artist of interest comes on the second page, despite full name match, and returns a different artist ("BiC Fizzle"):

```
genius = Genius("<TOKEN HERE>")
artist = genius.search_artist("Norther", allow_name_change=False)
```

**Solution**

Iterate over the results until we found the requested artist.

**Further steps**

Use same search technique for other entities like songs and albums.