### PR TITLE
Removed Headers & Added proxy support

### DIFF
--- a/lyricsgenius/api/api.py
+++ b/lyricsgenius/api/api.py
@@ -51,6 +51,7 @@ class API(Sender):
 
     def __init__(self,
                  access_token,
+                 proxy=None,
                  response_format='plain',
                  timeout=5,
                  sleep_time=0.2,
@@ -58,6 +59,7 @@ class API(Sender):
                  ):
         super().__init__(
             access_token=access_token,
+            proxy=proxy,
             response_format=response_format,
             timeout=timeout,
             sleep_time=sleep_time,

--- a/lyricsgenius/api/base.py
+++ b/lyricsgenius/api/base.py
@@ -16,7 +16,7 @@ class Sender(object):
     def __init__(
         self,
         access_token=None,
-        proxy=None
+        proxy=None,
         response_format='plain',
         timeout=5,
         sleep_time=0.2,

--- a/lyricsgenius/api/base.py
+++ b/lyricsgenius/api/base.py
@@ -16,6 +16,7 @@ class Sender(object):
     def __init__(
         self,
         access_token=None,
+        proxy=None
         response_format='plain',
         timeout=5,
         sleep_time=0.2,
@@ -23,10 +24,11 @@ class Sender(object):
         public_api_constructor=False,
     ):
         self._session = requests.Session()
-        self._session.headers = {
-            'application': 'LyricsGenius',
-            'User-Agent': 'https://github.com/johnwmillr/LyricsGenius'
-        }
+        self._session.proxies = proxy
+        # self._session.headers = {
+        #     'application': 'LyricsGenius',
+        #     'User-Agent': 'https://github.com/johnwmillr/LyricsGenius'
+        # }
         if access_token is None:
             access_token = os.environ.get('GENIUS_ACCESS_TOKEN')
 

--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -66,6 +66,7 @@ class Genius(API, PublicAPI):
                      'instrumental', 'setlist']
 
     def __init__(self, access_token=None,
+                 proxy=None,
                  response_format='plain', timeout=5, sleep_time=0.2,
                  verbose=True, remove_section_headers=False,
                  skip_non_songs=True, excluded_terms=None,
@@ -75,6 +76,7 @@ class Genius(API, PublicAPI):
         # Genius Client Constructor
         super().__init__(
             access_token=access_token,
+            proxy=proxy,
             response_format=response_format,
             timeout=timeout,
             sleep_time=sleep_time,


### PR DESCRIPTION
## Anyone facing `genius.search_song returns 403 Forbidden`.
As mentioned by @ItsJustAGitHubMichealWhosGonnaSeeIt5Ppl  before it was due to `headers`, but just removing them did't resolve the issue (for myself at least). but it can be fixed using proxy.

### How it works:
```python
import lyricsgenius

title="dead"
proxy = {'http': 'http://proxy_address:proxy_port', 'https': 'https://proxy_address:proxy_port'}
genius = lyricsgenius.Genius('..', proxy=proxy)
print(genius.search_song(title))
```