### PR TITLE
fix: iterate over results pages when searching for artist 

### DIFF
--- a/lyricsgenius/api/public_methods/search.py
+++ b/lyricsgenius/api/public_methods/search.py
@@ -7,7 +7,7 @@ class SearchMethods(object):
         Args:
             search_term (:obj:`str`): A term to search on Genius.
             per_page (:obj:`int`, optional): Number of results to
-                return per request. It can't be more than 50.
+                return per request. It can't be more than 5.
             page (:obj:`int`, optional): Paginated offset (number of the page).
             text_format (:obj:`str`, optional): Text format of the results
                 ('dom', 'html', 'markdown' or 'plain').

--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -75,6 +75,7 @@ class Genius(API, PublicAPI):
                  retries=0,
                  user_agent='',
                  proxy=None,
+                 per_page=5,
                  ):
         # Genius Client Constructor
         super().__init__(
@@ -90,6 +91,7 @@ class Genius(API, PublicAPI):
         self.verbose = verbose
         self.remove_section_headers = remove_section_headers
         self.skip_non_songs = skip_non_songs
+        self.per_page = per_page
 
         excluded_terms = excluded_terms if excluded_terms is not None else []
         if replace_default_terms:
@@ -507,11 +509,20 @@ class Genius(API, PublicAPI):
 
             # Perform a Genius API search for the artist
             found_artist = None
-            response = self.search_all(search_term)
-            found_artist = self._get_item_from_search_response(response,
-                                                               search_term,
-                                                               type_="artist",
-                                                               result_type="name")
+            page = 0
+            while not found_artist:
+                response = self.search_all(search_term, per_page=self.per_page, page=page)
+                result_count_on_page = max(map(lambda section: len(section["hits"]), response["sections"]))
+                if result_count_on_page == 0:
+                    break
+                has_more_pages = result_count_on_page == self.per_page
+                found_artist = self._get_item_from_search_response(response,
+                                                                   search_term,
+                                                                   type_="artist",
+                                                                   result_type="name")
+                page += 1
+                if not has_more_pages:
+                    break
 
             # Exit the search if we couldn't find an artist by the given name
             if not found_artist:

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -33,6 +33,12 @@ class TestArtist(unittest.TestCase):
         result = genius.search_artist(name, max_songs=0).songs
         self.assertEqual(0, len(result), msg)
 
+    def test_search_artist_not_on_the_first_results_page(self):
+        msg = "Different artist was returned."
+        name = "Norther"
+        result = genius.search_artist(name, max_songs=self.max_songs)
+        self.assertEqual(name, result.name, msg)
+
     def test_name(self):
         msg = "The artist object name does not match the requested artist name."
         self.assertEqual(self.artist.name, self.artist_name, msg)


### PR DESCRIPTION
**Problem**

When searching for a specific artist by name it currently requests 3 results per page per section (default value), not iterating over the next pages. 
In this example it happens that the artist of interest comes on the second page, despite full name match, and returns a different artist ("BiC Fizzle"):

```
genius = Genius("<TOKEN HERE>")
artist = genius.search_artist("Norther", allow_name_change=False)
```

**Solution**

Iterate over the results until we found the requested artist.

**Further steps**

Use same search technique for other entities like songs and albums.