### PR TITLE
Use get to avoid key error on body

### DIFF
--- a/lyricsgenius/types/artist.py
+++ b/lyricsgenius/types/artist.py
@@ -75,7 +75,7 @@ class Artist(BaseEntity):
                 )
             return None
         if new_song.artist == self.name or (
-            include_features and any(new_song._body["featured_artists"])
+            include_features and any(new_song._body.get("featured_artists", []))
         ):
             self.songs.append(new_song)
             self.num_songs += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyricsgenius"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = ["beautifulsoup4>=4.12.3", "requests>=2.27.1"]
 requires-python = ">=3.10"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ wheels = [
 
 [[package]]
 name = "lyricsgenius"
-version = "3.5.0"
+version = "3.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Fixes #216 by calling `body.get` instead of assuming `"featured_artists"` is a key in the dictionary.