### PR TITLE
Fix #317: Remove About section content from lyrics

### DIFF
--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -167,7 +167,7 @@ class Genius(API, PublicAPI):
         soup = BeautifulSoup(self._make_request(path, web=True)["html"], "html.parser")
 
         # Remove LyricsHeader divs from the DOM
-        removes = soup.find_all("div", class_=re.compile("LyricsHeader__Container"))
+        removes = soup.find_all("div", class_=re.compile("LyricsHeader"))
         if removes:
             for remove in removes:
                 remove.decompose()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyricsgenius"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = ["beautifulsoup4>=4.12.3", "requests>=2.27.1"]
 requires-python = ">=3.11"
 authors = [{ name = "John W. R. Miller", email = "john.w.millr+lg@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "lyricsgenius"
-version = "3.7.4"
+version = "3.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Resolves #317

The regex pattern was only matching `LyricsHeader__Container` divs, but nested About section content uses other class names like `LyricsHeader__GroupContainer`, `LyricsHeader__TitleContainer`, etc.

Changes:
- Update regex from `LyricsHeader__Container` to `LyricsHeader` to match all variants
- Bump version to 3.7.5

Tested with 'Verse Chorus Verse' by Nirvana - About section content now properly excluded.