### PR TITLE
feat: add primary_artists, writer_artists, and producer_artists to Song

### DIFF
--- a/lyricsgenius/types/song.py
+++ b/lyricsgenius/types/song.py
@@ -45,6 +45,9 @@ class Song(BaseEntity):
         self.title_with_featured: str | None = body.get("title_with_featured")
         self.url: str | None = body.get("url")
         self.featured_artists: list[dict[str, Any]] = body.get("featured_artists", [])
+        self.primary_artists: list[dict[str, Any]] = body.get("primary_artists", [])
+        self.writer_artists: list[dict[str, Any]] = body.get("writer_artists", [])
+        self.producer_artists: list[dict[str, Any]] = body.get("producer_artists", [])
 
     @property
     def _text_data(self) -> str:

--- a/main.py
+++ b/main.py
@@ -1,0 +1,16 @@
+import lyricsgenius
+
+genius = lyricsgenius.Genius()
+
+song = genius.search_song("Dr Hansjakobli und ds Babettli", "Mani Matter")
+
+song = genius.search_song("Dr Hansjakobli u ds Babettli", "Mani Matter")
+
+
+if song is not None:
+    print(song.lyrics)
+    song.save_lyrics("/Users/john/Downloads/song.txt", extension="txt", overwrite=True)
+
+song = genius.search_song("dua lipa", "new rules", False, False)
+if song is not None:
+    print(song.lyrics)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyricsgenius"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = ["beautifulsoup4>=4.12.3", "requests>=2.27.1"]
 requires-python = ">=3.11"
 authors = [{ name = "John W. R. Miller", email = "john.w.millr+lg@gmail.com" }]

--- a/tests/fixtures/song_info_mocked.json
+++ b/tests/fixtures/song_info_mocked.json
@@ -156,6 +156,53 @@
             "unreviewed_annotations": 3,
             "hot": false
         },
-        "featured_artists": []
+        "featured_artists": [
+            {
+                "id": 555555,
+                "name": "Mock Feature",
+                "api_path": "/artists/555555",
+                "header_image_url": "https://images.genius.com/mockfeature.jpg",
+                "image_url": "https://images.genius.com/mockfeature.jpg",
+                "is_meme_verified": false,
+                "is_verified": false,
+                "url": "https://genius.com/artists/Mock-feature"
+            }
+        ],
+        "primary_artists": [
+            {
+                "id": 424242,
+                "name": "Py Testerson",
+                "api_path": "/artists/424242",
+                "header_image_url": "https://images.genius.com/fakepythonartist.jpg",
+                "image_url": "https://images.genius.com/fakepythonartist.jpg",
+                "is_meme_verified": true,
+                "is_verified": false,
+                "url": "https://genius.com/artists/Py-testerson"
+            }
+        ],
+        "writer_artists": [
+            {
+                "id": 666666,
+                "name": "Test Writer",
+                "api_path": "/artists/666666",
+                "header_image_url": "https://images.genius.com/testwriter.jpg",
+                "image_url": "https://images.genius.com/testwriter.jpg",
+                "is_meme_verified": false,
+                "is_verified": false,
+                "url": "https://genius.com/artists/Test-writer"
+            }
+        ],
+        "producer_artists": [
+            {
+                "id": 777777,
+                "name": "Test Producer",
+                "api_path": "/artists/777777",
+                "header_image_url": "https://images.genius.com/testproducer.jpg",
+                "image_url": "https://images.genius.com/testproducer.jpg",
+                "is_meme_verified": false,
+                "is_verified": false,
+                "url": "https://genius.com/artists/Test-producer"
+            }
+        ]
     }
 ]

--- a/tests/test_song.py
+++ b/tests/test_song.py
@@ -81,6 +81,58 @@ def test_song_artist(song_object: Song, mock_song_data: dict[str, Any]) -> None:
     assert song_object.artist == mock_song_data["primary_artist"]["name"]
 
 
+def test_song_primary_artists(
+    song_object: Song, mock_song_data: dict[str, Any]
+) -> None:
+    """Test if primary_artists is populated correctly."""
+    assert song_object.primary_artists == mock_song_data["primary_artists"]
+    assert song_object.primary_artists[0]["name"] == "Py Testerson"
+
+
+def test_song_writer_artists(song_object: Song, mock_song_data: dict[str, Any]) -> None:
+    """Test if writer_artists is populated correctly."""
+    assert song_object.writer_artists == mock_song_data["writer_artists"]
+    assert song_object.writer_artists[0]["name"] == "Test Writer"
+
+
+def test_song_producer_artists(
+    song_object: Song, mock_song_data: dict[str, Any]
+) -> None:
+    """Test if producer_artists is populated correctly."""
+    assert song_object.producer_artists == mock_song_data["producer_artists"]
+    assert song_object.producer_artists[0]["name"] == "Test Producer"
+
+
+def test_song_featured_artists(
+    song_object: Song, mock_song_data: dict[str, Any]
+) -> None:
+    """Test if featured_artists is populated correctly."""
+    assert song_object.featured_artists == mock_song_data["featured_artists"]
+    assert song_object.featured_artists[0]["name"] == "Mock Feature"
+
+
+def test_song_artist_fields_default_empty(
+    mock_song_data: dict[str, Any], mock_lyrics: str
+) -> None:
+    """Test that artist list fields default to empty lists when absent from body."""
+    body = {
+        k: v
+        for k, v in mock_song_data.items()
+        if k
+        not in (
+            "primary_artists",
+            "writer_artists",
+            "producer_artists",
+            "featured_artists",
+        )
+    }
+    song = Song(mock_lyrics, body)
+    assert song.primary_artists == []
+    assert song.writer_artists == []
+    assert song.producer_artists == []
+    assert song.featured_artists == []
+
+
 def test_to_dict(
     song_object: Song, mock_song_data: dict[str, Any], mock_lyrics: str
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "lyricsgenius"
-version = "3.9.0"
+version = "3.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Closes #304

Adds three new fields to the `Song` type that expose artist role data from the Genius API response:

- `primary_artists` (from `body["primary_artists"]`)
- `writer_artists` (from `body["writer_artists"]`)
- `producer_artists` (from `body["producer_artists"]`)

All fields default to `[]` when absent, consistent with the existing `featured_artists` field. Tests and fixture data updated accordingly.