### PR TITLE
Remove deprecated verbose parameter

### DIFF
--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -6,7 +6,6 @@
 
 import logging
 import re
-import warnings
 from typing import Any
 
 from bs4 import BeautifulSoup, NavigableString, Tag
@@ -16,7 +15,6 @@ from .types import Album, Artist, Song
 from .types.types import ResponseFormatT, TextFormatT
 from .utils import clean_str, safe_unicode
 
-_UNSET: object = object()
 logger = logging.getLogger(__name__)
 
 
@@ -28,13 +26,6 @@ class Genius(API, PublicAPI):
         response_format (:obj:`str`, optional): API response format (dom, plain, html).
         timeout (:obj:`int`, optional): time before quitting on response (seconds).
         sleep_time (:obj:`str`, optional): time to wait between requests.
-        verbose: Deprecated. Use Python's ``logging`` module to control output.
-            To replicate the old ``verbose=True`` behaviour, configure the
-            ``lyricsgenius`` logger at ``INFO`` or ``DEBUG`` level::
-
-                import logging
-                logging.getLogger("lyricsgenius").setLevel(logging.DEBUG)
-
         remove_section_headers (:obj:`bool`, optional): If `True`, removes [Chorus],
             [Bridge], etc. headers from lyrics.
         skip_non_songs (:obj:`bool`, optional): If `True`, attempts to
@@ -102,7 +93,6 @@ class Genius(API, PublicAPI):
         response_format: ResponseFormatT = "plain",
         timeout: int = 5,
         sleep_time: float = 0.2,
-        verbose: object = _UNSET,
         remove_section_headers: bool = False,
         skip_non_songs: bool = True,
         excluded_terms: list[str] | None = None,
@@ -112,14 +102,6 @@ class Genius(API, PublicAPI):
         proxy: dict[str, str] | None = None,
         per_page: int = 5,
     ) -> None:
-        if verbose is not _UNSET:
-            warnings.warn(
-                "The 'verbose' parameter is deprecated and has no effect. "
-                "Configure logging instead: "
-                "logging.getLogger('lyricsgenius').setLevel(logging.DEBUG)",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if not 1 <= per_page <= 5:
             raise ValueError(
                 "per_page must be between 1 and 5 inclusive when using "

--- a/lyricsgenius/types/album.py
+++ b/lyricsgenius/types/album.py
@@ -1,11 +1,8 @@
-import warnings
 from typing import Any
 
 from ..utils import convert_to_datetime, format_filename
 from .base import BaseEntity
 from .song import Song
-
-_UNSET: object = object()
 
 
 class Album(BaseEntity):
@@ -89,16 +86,7 @@ class Album(BaseEntity):
         overwrite: bool = False,
         ensure_ascii: bool = True,
         sanitize: bool = True,
-        verbose: object = _UNSET,
     ) -> None:
-        if verbose is not _UNSET:
-            warnings.warn(
-                "The 'verbose' parameter is deprecated and has no effect. "
-                "Configure logging instead: "
-                "logging.getLogger('lyricsgenius').setLevel(logging.DEBUG)",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if filename is None:
             filename = format_filename(f"saved_album_lyrics_{self.artist}_{self.name}")
 

--- a/lyricsgenius/types/artist.py
+++ b/lyricsgenius/types/artist.py
@@ -4,14 +4,12 @@
 
 
 import logging
-import warnings
 from typing import Any
 
 from ..utils import format_filename, safe_unicode
 from .base import BaseEntity
 from .song import Song
 
-_UNSET: object = object()
 logger = logging.getLogger(__name__)
 
 
@@ -40,7 +38,6 @@ class Artist(BaseEntity):
     def add_song(
         self,
         new_song: Song,
-        verbose: object = _UNSET,
         include_features: bool = False,
     ) -> Song | None:
         """Adds a song to the Artist.
@@ -51,7 +48,6 @@ class Artist(BaseEntity):
 
         Args:
             new_song (:class:`Song <lyricsgenius.types.Song>`): Song to be added.
-            verbose: Deprecated. Use Python's ``logging`` module to control output.
             include_features (:obj:`bool`, optional): If True, includes tracks
                 featuring the artist.
 
@@ -68,14 +64,6 @@ class Artist(BaseEntity):
                 song = genius.search_song('To You', artist.name)
                 artist.add_song(song)
         """
-        if verbose is not _UNSET:
-            warnings.warn(
-                "The 'verbose' parameter is deprecated and has no effect. "
-                "Configure logging instead: "
-                "logging.getLogger('lyricsgenius').setLevel(logging.DEBUG)",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if new_song in self.songs:
             logger.debug(
                 "%s already in %s, not adding song.",
@@ -148,16 +136,7 @@ class Artist(BaseEntity):
         overwrite: bool = False,
         ensure_ascii: bool = True,
         sanitize: bool = True,
-        verbose: object = _UNSET,
     ) -> None:
-        if verbose is not _UNSET:
-            warnings.warn(
-                "The 'verbose' parameter is deprecated and has no effect. "
-                "Configure logging instead: "
-                "logging.getLogger('lyricsgenius').setLevel(logging.DEBUG)",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if filename is None:
             filename = format_filename(
                 f"saved_artist_lyrics_{self.name}_{self.num_songs}_songs"

--- a/lyricsgenius/types/song.py
+++ b/lyricsgenius/types/song.py
@@ -2,14 +2,11 @@
 # copyright 2026 John W. R. Miller
 # See LICENSE for details.
 
-import warnings
 from typing import Any
 
 from lyricsgenius.utils import format_filename
 
 from .base import BaseEntity
-
-_UNSET: object = object()
 
 
 class Song(BaseEntity):
@@ -84,16 +81,7 @@ class Song(BaseEntity):
         overwrite: bool = False,
         ensure_ascii: bool = True,
         sanitize: bool = True,
-        verbose: object = _UNSET,
     ) -> None:
-        if verbose is not _UNSET:
-            warnings.warn(
-                "The 'verbose' parameter is deprecated and has no effect. "
-                "Configure logging instead: "
-                "logging.getLogger('lyricsgenius').setLevel(logging.DEBUG)",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if filename is None:
             filename = format_filename(f"saved_song_lyrics_{self.artist}_{self.title}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyricsgenius"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = ["beautifulsoup4>=4.12.3", "requests>=2.27.1"]
 requires-python = ">=3.11"
 authors = [{ name = "John W. R. Miller", email = "john.w.millr+lg@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "lyricsgenius"
-version = "3.11.0"
+version = "3.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Closes #338

Removes the `verbose` parameter and `_UNSET` sentinel that were deprecated in v3.11.0 from:

- `Genius.__init__()`
- `Artist.add_song()`
- `Artist.save_lyrics()`
- `Song.save_lyrics()`
- `Album.save_lyrics()`

Also drops the now-unused `import warnings` from each file. Bumps to v3.12.0.