### PR TITLE
Fix album.save_lyrics default filename generation

### DIFF
--- a/lyricsgenius/types/album.py
+++ b/lyricsgenius/types/album.py
@@ -88,7 +88,9 @@ class Album(BaseEntity):
         sanitize: bool = True,
     ) -> None:
         if filename is None:
-            filename = format_filename(f"saved_album_lyrics_{self.artist}_{self.name}")
+            filename = format_filename(
+                f"saved_album_lyrics_{self.artist['name']}_{self.name}"
+            )
 
         return super().save_lyrics(
             filename=filename,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyricsgenius"
-version = "3.12.0"
+version = "3.12.1"
 dependencies = ["beautifulsoup4>=4.12.3", "requests>=2.27.1"]
 requires-python = ">=3.11"
 authors = [{ name = "John W. R. Miller", email = "john.w.millr+lg@gmail.com" }]

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -212,6 +212,28 @@ def test_saving_txt_file(album_object: Album, tmp_path: Path) -> None:
     album_object.tracks[0][1].lyrics = original_lyrics
 
 
+def test_default_save_lyrics_filename_uses_artist_name(
+    album_object: Album, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    album_object.save_lyrics(overwrite=True)
+
+    expected_filepath = (
+        tmp_path / "saved_album_lyrics_py_testerson_mocking_the_tests.json"
+    )
+    assert expected_filepath.is_file(), (
+        f"Default file not created at {expected_filepath}"
+    )
+
+    created_files = list(tmp_path.iterdir())
+    assert len(created_files) == 1
+    assert created_files[0].name == expected_filepath.name
+
+    content = expected_filepath.read_text()
+    assert f'"artist": "{album_object.artist["name"]}"' in content, content
+
+
 @pytest.fixture
 def genius_client() -> Genius:
     return Genius("dummy_access_token", sleep_time=0)

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "lyricsgenius"
-version = "3.12.0"
+version = "3.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Fixes #346.

`Album.save_lyrics()` was building its default filename from the full `artist` object instead of the artist name, which could produce invalid filenames on Windows.

This PR updates the default filename generation to use `artist["name"]`, adds a regression test for the default save path, and bumps the package version to `3.12.1`.