### PR TITLE
Fix search_song artist matching for ambiguous titles (#336)

### DIFF
--- a/lyricsgenius/genius.py
+++ b/lyricsgenius/genius.py
@@ -245,7 +245,12 @@ class Genius(API, PublicAPI):
         return not re.search(regex, song["title"], flags=re.IGNORECASE)
 
     def _get_item_from_search_response(
-        self, response: dict[str, Any], search_term: str, type_: str, result_type: str
+        self,
+        response: dict[str, Any],
+        search_term: str,
+        type_: str,
+        result_type: str,
+        artist: str | None = None,
     ) -> dict[str, Any] | None:
         """Gets the desired item from the search results.
 
@@ -287,7 +292,10 @@ class Genius(API, PublicAPI):
 
         for hit in hits:
             item = hit["result"]
-            if clean_str(item[result_type]) == clean_str(search_term):
+            if type_ == "song" and result_type == "title":
+                if self._result_is_match(item, search_term, artist):
+                    return item
+            elif clean_str(item[result_type]) == clean_str(search_term):
                 return item
 
         # If the desired type is song lyrics and none of the results matched,
@@ -295,8 +303,15 @@ class Genius(API, PublicAPI):
         if type_ == "song" and self.skip_non_songs:
             for hit in hits:
                 song: dict[str, Any] = hit["result"]
+                if artist and clean_str(song["primary_artist"]["name"]) != clean_str(
+                    artist
+                ):
+                    continue
                 if self._result_is_lyrics(song):
                     return song
+
+        if type_ == "song" and artist:
+            return None
 
         return hits[0]["result"] if hits else None
 
@@ -506,7 +521,11 @@ class Genius(API, PublicAPI):
             # Try search/multi first (the comprehensive search)
             search_response = self.search_all(search_term)
             song_info = self._get_item_from_search_response(
-                search_response, title, type_="song", result_type="title"
+                search_response,
+                title,
+                type_="song",
+                result_type="title",
+                artist=artist,
             )
 
             # If search/multi returns no results, fallback to regular /search
@@ -519,7 +538,7 @@ class Genius(API, PublicAPI):
                     # Try to find an exact match first
                     for hit in search_response["hits"]:
                         result = hit["result"]
-                        if clean_str(result.get("title", "")) == clean_str(title):
+                        if self._result_is_match(result, title, artist):
                             song_info = result
                             break
 
@@ -530,6 +549,10 @@ class Genius(API, PublicAPI):
                             result = hit["result"]
                             # Verify it's a song by checking for expected fields
                             if "primary_artist" in result and "url" in result:
+                                if artist and clean_str(
+                                    result["primary_artist"]["name"]
+                                ) != clean_str(artist):
+                                    continue
                                 song_info = result
                                 break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyricsgenius"
-version = "3.12.1"
+version = "3.12.2"
 dependencies = ["beautifulsoup4>=4.12.3", "requests>=2.27.1"]
 requires-python = ">=3.11"
 authors = [{ name = "John W. R. Miller", email = "john.w.millr+lg@gmail.com" }]

--- a/tests/test_search_song_matching.py
+++ b/tests/test_search_song_matching.py
@@ -1,0 +1,60 @@
+from typing import Any
+from unittest import mock
+
+from lyricsgenius import Genius
+
+
+def _song_hit(song_id: int, title: str, artist: str) -> dict[str, Any]:
+    return {
+        "index": "song",
+        "result": {
+            "id": song_id,
+            "title": title,
+            "primary_artist": {"name": artist},
+            "lyrics_state": "incomplete",
+            "instrumental": False,
+            "url": f"https://example.com/{song_id}",
+        },
+    }
+
+
+def _search_all_response(song_hits: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "sections": [
+            {"type": "top_hits", "hits": song_hits[:1]},
+            {"type": "song", "hits": song_hits},
+        ]
+    }
+
+
+def test_search_song_prefers_exact_title_with_matching_artist() -> None:
+    g = Genius("dummy_access_token", sleep_time=0, skip_non_songs=False)
+    search_all_response = _search_all_response(
+        [
+            _song_hit(1, "Santa", "Fedez"),
+            _song_hit(2, "Santa", "Madonna"),
+        ]
+    )
+
+    with (
+        mock.patch.object(g, "search_all", return_value=search_all_response),
+        mock.patch.object(g, "search", return_value={"hits": []}),
+    ):
+        result = g.search_song("Santa", artist="Madonna", get_full_info=False)
+
+    assert result is not None
+    assert result.title == "Santa"
+    assert result.artist == "Madonna"
+
+
+def test_search_song_returns_none_when_artist_does_not_match() -> None:
+    g = Genius("dummy_access_token", sleep_time=0, skip_non_songs=False)
+    search_all_response = _search_all_response([_song_hit(1, "Santa", "Fedez")])
+
+    with (
+        mock.patch.object(g, "search_all", return_value=search_all_response),
+        mock.patch.object(g, "search", return_value={"hits": []}),
+    ):
+        result = g.search_song("Santa", artist="Madonna", get_full_info=False)
+
+    assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "lyricsgenius"
-version = "3.12.1"
+version = "3.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed
- `search_song()` now respects the artist when an artist is explicitly provided
- avoids falling back to the wrong artist on ambiguous titles
- adds regression tests for matching and non-matching artist cases
- resolves #336 

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q`

## Version
- bumps patch version to `3.12.2`