### PR TITLE
Add --output-file CLI option for custom output filenames (#345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ python -m lyricsgenius song "Begin Again" "Andy Shauf" --format json --save
 # Save a song's lyrics in both JSON and text formats
 python -m lyricsgenius song "Begin Again" "Andy Shauf" --format json txt --save
 
+# Save a song's lyrics with a custom filename
+python -m lyricsgenius song "Begin Again" "Andy Shauf" --format json --save --output-file my_song
+
 # Save an artist's lyrics to text files (stopping after 2 songs)
 python -m lyricsgenius artist "The Beatles" --max-songs 2 --format txt --save
 ```

--- a/lyricsgenius/__main__.py
+++ b/lyricsgenius/__main__.py
@@ -36,12 +36,17 @@ class Searcher:
         if not (result := self.search_func(*args.terms, **kwargs)):
             return
 
+        output_file = getattr(args, "output_file", None)
         for format in args.format:
             if not args.save:
                 print(result.to_text() if format == "txt" else result.to_json())
             else:
                 logger.info("Saving lyrics in %s format.", format.upper())
-                result.save_lyrics(extension=format, overwrite=args.overwrite)
+                result.save_lyrics(
+                    filename=output_file,
+                    extension=format,
+                    overwrite=args.overwrite,
+                )
 
 
 def main() -> None:
@@ -86,6 +91,12 @@ def main() -> None:
         action="store_true",
         default=False,
         help="Overwrite the file if it already exists",
+    )
+    optional.add_argument(
+        "--output-file",
+        type=str,
+        default=None,
+        help="Specify output filename when using --save",
     )
     optional.add_argument(
         "-n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyricsgenius"
-version = "3.12.1"
+version = "3.13.0"
 dependencies = ["beautifulsoup4>=4.12.3", "requests>=2.27.1"]
 requires-python = ">=3.11"
 authors = [{ name = "John W. R. Miller", email = "john.w.millr+lg@gmail.com" }]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+from argparse import Namespace
+from typing import cast
+from unittest import mock
+
+from lyricsgenius import Genius
+from lyricsgenius.__main__ import Searcher
+
+
+class _DummyAPI:
+    def __init__(self, result: object | None) -> None:
+        self.search_song = mock.Mock(return_value=result)
+        self.search_artist = mock.Mock(return_value=result)
+        self.search_album = mock.Mock(return_value=result)
+
+
+def _args(save: bool, output_file: str | None = None) -> Namespace:
+    return Namespace(
+        terms=["Santa", "Madonna"],
+        format=["json", "txt"],
+        save=save,
+        overwrite=True,
+        output_file=output_file,
+        max_songs=None,
+    )
+
+
+def test_searcher_passes_output_file_to_save_lyrics() -> None:
+    result = mock.Mock()
+    api = _DummyAPI(result)
+
+    Searcher(cast(Genius, api), "song")(_args(save=True, output_file="custom_name"))
+
+    assert result.save_lyrics.call_count == 2
+    result.save_lyrics.assert_any_call(
+        filename="custom_name", extension="json", overwrite=True
+    )
+    result.save_lyrics.assert_any_call(
+        filename="custom_name", extension="txt", overwrite=True
+    )
+
+
+def test_searcher_uses_default_filename_when_output_file_is_none() -> None:
+    result = mock.Mock()
+    api = _DummyAPI(result)
+
+    Searcher(cast(Genius, api), "song")(_args(save=True, output_file=None))
+
+    assert result.save_lyrics.call_count == 2
+    result.save_lyrics.assert_any_call(filename=None, extension="json", overwrite=True)
+    result.save_lyrics.assert_any_call(filename=None, extension="txt", overwrite=True)
+
+
+def test_searcher_prints_when_not_saving() -> None:
+    result = mock.Mock()
+    result.to_json.return_value = '{"ok": true}'
+    result.to_text.return_value = "ok"
+    api = _DummyAPI(result)
+
+    with mock.patch("builtins.print") as print_mock:
+        Searcher(cast(Genius, api), "song")(_args(save=False, output_file="ignored"))
+
+    result.save_lyrics.assert_not_called()
+    assert print_mock.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "lyricsgenius"
-version = "3.12.1"
+version = "3.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed
- adds `--output-file` to the CLI for saving with a custom filename
- passes the filename through to `save_lyrics()` when `--save` is used
- keeps existing `-o/--overwrite` behavior unchanged
- adds CLI tests for `Searcher` save/print behavior
- updates README examples
- resolves #345 

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q`

## Version
- bumps minor version to `3.13.0`